### PR TITLE
Added sensu plugin for stashing alerts

### DIFF
--- a/plugins/sensu.py
+++ b/plugins/sensu.py
@@ -1,0 +1,57 @@
+'''!stash [client-name] [reason]'''
+import urllib, urllib2
+import json
+import os
+import time
+
+DEFAULT_EXPIRE = int(os.getenv('SENSU_STASH_EXPIRE', 3600*24))    # 24 hr, unit: seconds
+SENSU_API_BASE_URL = os.getenv('SENSU_API_BASE_URL', 'http://sensu.vkportal.com:4567')
+STASHES_URL = '{}/stashes'.format(SENSU_API_BASE_URL)
+CLIENTS_URL = '{}/clients'.format(SENSU_API_BASE_URL)
+
+SOURCE = os.getenv('SENSU_STASH_SOURCE', 'slack')
+
+
+def createStash(msg):
+    # msg should be "!stash <name> <reason>"
+    pieces = msg.split(' ', 2)
+    if len(pieces) != 3:
+        return ''
+
+    name = pieces[1]
+    reason = pieces[2]
+
+    if not clientExists(name):
+        return 'Could not find a client named {}'.format(name)
+
+    payload = createPayload(name, reason)
+
+    urllib2.urlopen(STASHES_URL, json.dumps(payload))
+    return 'Stash created!'
+
+
+def clientExists(name):
+    res = urllib2.urlopen(CLIENTS_URL)
+    body = res.read()
+    j = json.loads(body)
+    return len([x for x in j if x['name'] == name]) == 1
+
+
+def createPayload(name, reason):
+    return {
+        'path': 'silence/{}'.format(name),
+        'expire': DEFAULT_EXPIRE,
+        'content': {
+            'reason': reason,
+            'source': SOURCE,
+            'timestamp': int(time.time())
+        }
+    }
+
+def on_message(msg, server):
+    test = msg.get('test', '')
+    match = re.findall(r'!stash( .*)+', text)
+    if not match: return
+
+    return createStash(msg)
+


### PR DESCRIPTION
You can create stashed now by doing something like:

!stash <client-name> <reason>

e.x.
'!stash api.mywebsite.com because i dont like to be bothered'

And a stash will be created to silence alerts from api.website.com.

Note: the client-name is the name of the Sensu client, not the IP.

configuration (environment variables):

SENSU_API_BASE_URL: the base URL for the Sensu API (default: http://sensu.vkportal.com:4567)
SENSU_STASH_EXPIRE: how long before the stash expires in seconds (default: 86400 or 24h)
SENSU_STASH_SOURCE: where the stash is coming from (default: slack)